### PR TITLE
Fix minor issues in the throughput tool

### DIFF
--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -174,14 +174,14 @@ fn do_server(iface_name: String) {
             Err(_) => continue,
         };
 
-        let eth_pkt: EthernetPacket = EthernetPacket::new(&packet).unwrap();
-        if eth_pkt.get_ethertype() != EtherType(ETHERTYPE_PERF) {
+        let src_eth_pkt: EthernetPacket = EthernetPacket::new(&packet).unwrap();
+        if src_eth_pkt.get_ethertype() != EtherType(ETHERTYPE_PERF) {
             continue;
         }
 
-        let perf_pkt: PerfPacket = PerfPacket::new(eth_pkt.payload()).unwrap();
+        let src_perf_pkt: PerfPacket = PerfPacket::new(src_eth_pkt.payload()).unwrap();
 
-        match perf_pkt.get_op() {
+        match src_perf_pkt.get_op() {
             PerfOpFieldValues::ReqStart => {
                 println!("Received ReqStart");
 
@@ -191,7 +191,7 @@ fn do_server(iface_name: String) {
                 }
 
                 let req_start: PerfStartReqPacket =
-                    PerfStartReqPacket::new(perf_pkt.payload()).unwrap();
+                    PerfStartReqPacket::new(src_perf_pkt.payload()).unwrap();
                 let duration: Duration = Duration::from_secs(req_start.get_duration().into());
 
                 unsafe {
@@ -209,11 +209,11 @@ fn do_server(iface_name: String) {
                 let mut eth_buffer = vec![0; 14 + 8];
 
                 let mut perf_pkt = MutablePerfPacket::new(&mut perf_buffer).unwrap();
-                perf_pkt.set_id(perf_pkt.get_id());
+                perf_pkt.set_id(src_perf_pkt.get_id());
                 perf_pkt.set_op(PerfOpFieldValues::ResStart);
 
                 let mut eth_pkt = MutableEthernetPacket::new(&mut eth_buffer).unwrap();
-                eth_pkt.set_destination(eth_pkt.get_source());
+                eth_pkt.set_destination(src_eth_pkt.get_source());
                 eth_pkt.set_source(my_mac);
                 eth_pkt.set_ethertype(EtherType(ETHERTYPE_PERF));
 
@@ -224,7 +224,7 @@ fn do_server(iface_name: String) {
             }
             PerfOpFieldValues::Data => {
                 unsafe {
-                    STATS.last_id = perf_pkt.get_id();
+                    STATS.last_id = src_perf_pkt.get_id();
                     STATS.pkt_count += 1;
                     STATS.total_bytes += packet_size + 4/* hidden VLAN tag */;
                 }
@@ -238,11 +238,11 @@ fn do_server(iface_name: String) {
                 let mut eth_buffer = vec![0; 14 + 8];
 
                 let mut perf_pkt = MutablePerfPacket::new(&mut perf_buffer).unwrap();
-                perf_pkt.set_id(perf_pkt.get_id());
+                perf_pkt.set_id(src_perf_pkt.get_id());
                 perf_pkt.set_op(PerfOpFieldValues::ResEnd);
 
                 let mut eth_pkt = MutableEthernetPacket::new(&mut eth_buffer).unwrap();
-                eth_pkt.set_destination(eth_pkt.get_source());
+                eth_pkt.set_destination(src_eth_pkt.get_source());
                 eth_pkt.set_source(my_mac);
                 eth_pkt.set_ethertype(EtherType(ETHERTYPE_PERF));
 

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -353,7 +353,7 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
 
         last_id += 1;
 
-        if now.elapsed().as_secs() > duration as u64 || !unsafe { RUNNING } {
+        if now.elapsed().as_secs() >= duration as u64 || !unsafe { RUNNING } {
             break;
         }
     }


### PR DESCRIPTION
스루풋 툴의 아래 문제들을 수정합니다.

1. server 측에서 client 측의 request에 대해 응답할 때, ID와 source 주소를 잘못 참조하고 있습니다.
 - 예를 들어 212번 줄의 경우, perf_pkt가 자신의 id를 읽어 다시 자신의 id에 덮어쓰고 있습니다.
 - 이는 source address도 마찬가지이며, 이로 인해 destination address가 항상 `00:00:00:00:00:00` 으로 설정됩니다.
 - 182번 줄의 perf_pkt를 참조하는 것을 의도한 것으로 보여, 두 개의 perf_pkt의 이름을 다르게 하였습니다.
 - 이는 eth_pkt도 마찬가지입니다.


2. duration과 실제 경과 시간을 비교할 때, 등호를 넣어주지 않으면 의도한 것보다 1초 더 패킷을 보냅니다.
 - 356번 줄의 now.elapsed().as_secs()가 0부터 시작하기 때문에 발생하는 문제로 보입니다.
 - 예를 들어, duration을 3초로 주었을 경우 `0 / 1 / 2 / 3` 4초 동안 패킷이 전송됩니다.