### PR TITLE
Implement Rx Timestamp API

### DIFF
--- a/src/bin/latency.rs
+++ b/src/bin/latency.rs
@@ -301,11 +301,11 @@ fn do_client(args: ClientArgs) {
     eth_pkt.set_ethertype(EtherType(ETHERTYPE_PERF));
 
     let mut rx_eth_buff = [0u8; 1514];
+    let mut iov: libc::iovec = libc::iovec {
+        iov_base: rx_eth_buff.as_mut_ptr() as *mut libc::c_void,
+        iov_len: rx_eth_buff.len(),
+    };
     if !args.oneway {
-        let mut iov: libc::iovec = libc::iovec {
-            iov_base: rx_eth_buff.as_mut_ptr() as *mut libc::c_void,
-            iov_len: rx_eth_buff.len(),
-        };
         if sock.enable_rx_timestamp(&mut iov).is_err() {
             eprintln!("Failed to enable RX timestamp");
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,12 @@ impl TsnSocket {
         enable_tx_timestamp(self)
     }
 
-    pub fn enable_rx_timestamp(&self, iov: &mut libc::iovec) -> Result<msghdr, String> {
-        enable_rx_timestamp(self, iov)
-    }
-
     pub fn get_tx_timestamp(&self) -> Result<time::Timespec, Error> {
         get_tx_timestamp(self)
+    }
+
+    pub fn enable_rx_timestamp(&self, iov: &mut libc::iovec) -> Result<msghdr, String> {
+        enable_rx_timestamp(self, iov)
     }
 
     pub fn get_rx_timestamp(&self, msg: msghdr) -> Result<SystemTime, u32> {


### PR DESCRIPTION
Rx 타임스탬프 API를 추가합니다. (#67)

기존 latency.rs에 있던 함수를 lib.rs로 옮긴 후 TsnSocket의 메소드로 추가하였으며,
Tx 타임스탬프와의 일관성을 위해 인자와 반환값 타입을 수정하였습니다.

Closing: sw-846