### PR TITLE
Minor throughput tool fixes

### DIFF
--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -313,6 +313,8 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
     eth_pkt.set_ethertype(EtherType(ETHERTYPE_PERF));
     eth_pkt.set_payload(perf_pkt.packet());
 
+    let mut response_received = false;
+
     for _ in 0..3 {
         if let Err(e) = sock.send(eth_pkt.packet()) {
             eprintln!("Failed to send packet: {}", e)
@@ -320,8 +322,16 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
 
         match wait_for_response(&mut sock, PerfOpFieldValues::ResStart) {
             Err(_) => eprintln!("No response, retrying..."),
-            Ok(_) => break,
+            Ok(_) => {
+                response_received = true;
+                break;
+            },
         }
+    }
+
+    if !response_received {
+        eprintln!("Server is not responding");
+        return;
     }
 
     unsafe {

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -165,6 +165,8 @@ fn do_server(iface_name: String) {
         }
     });
 
+    let mut received_first_data = false;
+
     while unsafe { RUNNING } {
         let mut packet = [0u8; 1514];
         let packet_size;
@@ -202,9 +204,6 @@ fn do_server(iface_name: String) {
                     TEST_RUNNING = true;
                 }
 
-                // Make thread for statistics
-                thread::spawn(stats_worker);
-
                 let mut perf_buffer = vec![0; 8];
                 let mut eth_buffer = vec![0; 14 + 8];
 
@@ -223,6 +222,11 @@ fn do_server(iface_name: String) {
                 }
             }
             PerfOpFieldValues::Data => {
+                if !received_first_data {
+                    // Make thread for statistics
+                    received_first_data = true;
+                    thread::spawn(stats_worker);
+                }
                 unsafe {
                     STATS.last_id = perf_pkt.get_id();
                     STATS.pkt_count += 1;
@@ -233,6 +237,7 @@ fn do_server(iface_name: String) {
                 println!("Received ReqEnd");
 
                 unsafe { TEST_RUNNING = false }
+                received_first_data = false;
 
                 let mut perf_buffer = vec![0; 8];
                 let mut eth_buffer = vec![0; 14 + 8];


### PR DESCRIPTION
Throughput 도구에서 아래 두 가지 이슈를 수정합니다.

1. Server측에서 Request를 받았을 때 바로 통계 스레드를 시작하여 첫 1초의 통계가 정확하지 않은 문제
   - 이제 첫 Data 패킷을 받았을 때에 통계 스레드를 시작합니다.

2. Client측에서 Server의 Response를 받지 못했음에도 Throughput 측정을 계속 진행하려고 시도하는 문제
   - 이제 3번 시도해도 Response를 받지 못하면 App을 바로 종료합니다.

closing: sw-847, sw-849