### PR TITLE
Add warmup parameter to throughput tool

### DIFF
--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -451,8 +451,6 @@ fn stats_worker() {
     let mut last_id = 0;
     let mut last_bytes = 0;
     let mut last_packets = 0;
-    let start_time = Instant::now();
-    let mut last_time = start_time;
 
     const SECOND: Duration = Duration::from_secs(1);
 
@@ -462,6 +460,9 @@ fn stats_worker() {
         println!("Finished warmup");
         stats.warming_up = false;
     }
+
+    let start_time = Instant::now();
+    let mut last_time = start_time;
 
     while unsafe { TEST_RUNNING } {
         let elapsed = last_time.elapsed();
@@ -478,7 +479,7 @@ fn stats_worker() {
         let packets = total_packets - last_packets;
         let loss_rate = 1.0 - packets as f64 / (id - last_id) as f64;
 
-        let lap = start_time.elapsed().as_secs() - stats.warmup as u64;
+        let lap = start_time.elapsed().as_secs();
 
         if lap > stats.duration as u64 {
             unsafe {

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -461,6 +461,8 @@ fn stats_worker() {
         stats.warming_up = false;
     }
 
+    last_id = stats.last_id;
+
     let start_time = Instant::now();
     let mut last_time = start_time;
 

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -310,9 +310,9 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize, w
 
     // Request start
     println!("Requesting start");
-    let mut req_start_buffer = vec![0; 4];
-    let mut perf_buffer = vec![0; 8 + 4];
-    let mut eth_buffer = vec![0; 14 + 8 + 4];
+    let mut req_start_buffer = vec![0; 8];
+    let mut perf_buffer = vec![0; 8 + 8];
+    let mut eth_buffer = vec![0; 14 + 8 + 8];
 
     let mut perf_req_start_pkt = MutablePerfStartReqPacket::new(&mut req_start_buffer).unwrap();
     perf_req_start_pkt.set_duration(duration.try_into().unwrap());

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -242,8 +242,8 @@ fn do_server(iface_name: String) {
             }
             PerfOpFieldValues::Data => {
                 unsafe {
+                    STATS.last_id = perf_pkt.get_id();
                     if !STATS.warming_up {
-                        STATS.last_id = perf_pkt.get_id();
                         STATS.pkt_count += 1;
                         STATS.total_bytes += packet_size + 4/* hidden VLAN tag */;
                     }

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -258,11 +258,11 @@ fn do_server(iface_name: String) {
                 let mut eth_buffer = vec![0; 14 + 8];
 
                 let mut perf_pkt = MutablePerfPacket::new(&mut perf_buffer).unwrap();
-                perf_pkt.set_id(perf_pkt.get_id());
+                perf_pkt.set_id(recv_perf_pkt.get_id());
                 perf_pkt.set_op(PerfOpFieldValues::ResEnd);
 
                 let mut eth_pkt = MutableEthernetPacket::new(&mut eth_buffer).unwrap();
-                eth_pkt.set_destination(eth_pkt.get_source());
+                eth_pkt.set_destination(recv_eth_pkt.get_source());
                 eth_pkt.set_source(my_mac);
                 eth_pkt.set_ethertype(EtherType(ETHERTYPE_PERF));
 

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -165,8 +165,6 @@ fn do_server(iface_name: String) {
         }
     });
 
-    let mut received_first_data = false;
-
     while unsafe { RUNNING } {
         let mut packet = [0u8; 1514];
         let packet_size;
@@ -204,6 +202,9 @@ fn do_server(iface_name: String) {
                     TEST_RUNNING = true;
                 }
 
+                // Make thread for statistics
+                thread::spawn(stats_worker);
+
                 let mut perf_buffer = vec![0; 8];
                 let mut eth_buffer = vec![0; 14 + 8];
 
@@ -222,11 +223,6 @@ fn do_server(iface_name: String) {
                 }
             }
             PerfOpFieldValues::Data => {
-                if !received_first_data {
-                    // Make thread for statistics
-                    received_first_data = true;
-                    thread::spawn(stats_worker);
-                }
                 unsafe {
                     STATS.last_id = perf_pkt.get_id();
                     STATS.pkt_count += 1;
@@ -237,7 +233,6 @@ fn do_server(iface_name: String) {
                 println!("Received ReqEnd");
 
                 unsafe { TEST_RUNNING = false }
-                received_first_data = false;
 
                 let mut perf_buffer = vec![0; 8];
                 let mut eth_buffer = vec![0; 14 + 8];

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -110,6 +110,11 @@ fn main() {
             arg!(duration: -d --duration <duration>)
                 .required(false)
                 .default_value("10"),
+        )
+        .arg(
+            arg!(warmup: -w --warmup <warmup>)
+                .required(false)
+                .default_value("0"),
         );
 
     let matched_command = Command::new("throughput")

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -478,7 +478,7 @@ fn stats_worker() {
         let packets = total_packets - last_packets;
         let loss_rate = 1.0 - packets as f64 / (id - last_id) as f64;
 
-        let lap = start_time.elapsed().as_secs();
+        let lap = start_time.elapsed().as_secs() - stats.warmup as u64;
 
         if lap > stats.duration as u64 {
             unsafe {


### PR DESCRIPTION
이전에 첫 데이터 패킷을 받은 뒤에 통계를 집계하도록 한 것을 되돌리고, warmup 옵션을 추가했습니다.

Client에서 처음 Reqeust를 보낼 때 warmup duration을 보내면, 그 시간이 지난 뒤에 통계 집계를 시작합니다.

`--warmup n` 또는 `-w n` 과 같이 사용할 수 있으며,
기본값은 0입니다.

closing: sw-971