### PR TITLE
Implement bitrate option for throughput tool

### DIFF
--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -408,7 +408,7 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize, w
             elapsed_ns = current_time.duration_since(last_send_time).as_nanos() as u64;
         }
 
-        if now.elapsed().as_secs() > (duration + warmup) as u64 || !unsafe { RUNNING } {
+        if now.elapsed().as_secs() >= (duration + warmup) as u64 || !unsafe { RUNNING } {
             break;
         }
 


### PR DESCRIPTION
Throughput 측정 도구의 client 측에 bitrate 옵션을 추가합니다. Client측에서 전송하는 bps를 지정된 값으로 제한합니다.
`--bitrate n`, `-b n` 과 같이 사용할 수 있으며, 기본값은 1Gbps 입니다.

아래는 각각 10Mbps, 20Mbps로 제한해 테스트한 결과입니다. 지정된 값과 조금 차이가 있지만, 이 이상 정확도를 올리기는 쉽지 않을 것으로 보입니다.

![image](https://github.com/user-attachments/assets/5b5ba8ef-b185-415c-9b77-4f33d53a8817)

closing: sw-848